### PR TITLE
Adding TelemetryCorrelationHttpModule into web.config when user enable AI.

### DIFF
--- a/AppInsightsProvider/AITelemetry.cs
+++ b/AppInsightsProvider/AITelemetry.cs
@@ -1,0 +1,247 @@
+﻿// -----------------------------------------------------------------------
+//  <copyright file="AITelemetry.cs" company="Dominion Enterprise">
+//       Copyright (c) Dominion Enterprise LLC. All rights reserved.
+//  </copyright>
+// -----------------------------------------------------------------------
+
+namespace DotNetNuke.Monitoring.AppInsights
+{
+    using System;
+    using System.Configuration;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    public static class Dx1Configuration
+    {
+        private const string EnvironmentPreFix = "APPSETTING_";
+
+        private static string GetAzureAppSetting(string appSettingKey)
+        {
+            var key = EnvironmentPreFix + appSettingKey;
+            return Environment.GetEnvironmentVariable(key);
+
+        }
+
+        public static string GetSetting(string settingKey)
+        {
+            var azureValue = GetAzureAppSetting(settingKey);
+            if (!string.IsNullOrEmpty(azureValue))
+            {
+                return azureValue;
+            }
+            return GetSettingFromConfigFile(settingKey);
+        }
+
+        private static string GetSettingFromConfigFile(string settingKey)
+        {
+            return ConfigurationManager.AppSettings[settingKey];
+        }
+    }
+
+
+    public class TelemetryInitializer : ITelemetryInitializer
+    {
+
+        private string NewOperationName(string operationaName)
+        {
+            return "DX1DNN " + operationaName;
+        }
+
+        /// <summary>
+        /// Set the AI base settings for all events
+        /// </summary>
+        /// <param name="telemetry"></param>
+        public void Initialize(ITelemetry telemetry)
+        {
+            //change the way we track operation name
+            var telemetryType = telemetry as RequestTelemetry;
+            var name = NewOperationName(telemetry.Context.Operation.Name);
+
+            if (telemetryType != null)
+            {
+                telemetryType.Name = name;
+            }
+
+            // Get the website name from azure environment
+            var webname = Environment.GetEnvironmentVariable("WEBSITE_SITE_NAME");
+            if (string.IsNullOrEmpty(webname))
+            {
+                webname = Environment.MachineName;
+            }
+
+            // this is how to add properties to every telemetry item sent
+            // Check to see if we are already initiated
+            if (!telemetry.Context.Properties.ContainsKey("GEO"))
+            {
+                telemetry.Context.Properties.Add("GEO", Dx1Configuration.GetSetting("GEO"));
+            }
+            if (!telemetry.Context.Properties.ContainsKey("App"))
+            {
+                telemetry.Context.Properties.Add("App", "DX1DNN");
+            }
+
+            if (!telemetry.Context.Properties.ContainsKey("PodName"))
+            {
+                telemetry.Context.Properties.Add("PodName", webname);
+            }
+            telemetry.Context.Component.Version = "DX1DNN";
+        }
+    }
+
+    public class DependencyFilter : ITelemetryProcessor
+    {
+        private ITelemetryProcessor Next { get; set; }
+
+        // You can pass values from .config
+        public string MyParamFromConfigFile { get; set; }
+
+        // Link processors to each other in a chain.
+        public DependencyFilter(ITelemetryProcessor next)
+        {
+            this.Next = next;
+        }
+        public void Process(ITelemetry item)
+        {
+
+            var sqlMs = Dx1Configuration.GetSetting("SqlMs");
+            var queueMs = Dx1Configuration.GetSetting("QueueMs");
+            var blobMs = Dx1Configuration.GetSetting("BlobMs");
+            var tableMs = Dx1Configuration.GetSetting("TableMs");
+            var httpMs = Dx1Configuration.GetSetting("HttpMs");
+
+            var trackSqlConnection = Dx1Configuration.GetSetting("TrackSqlConnection");
+
+            int sqlMsTime;
+            int.TryParse(sqlMs, out sqlMsTime);
+
+            int queueMsTime;
+            int.TryParse(queueMs, out queueMsTime);
+
+            int blobMsTime;
+            int.TryParse(blobMs, out blobMsTime);
+
+            int tableMsTime;
+            int.TryParse(tableMs, out tableMsTime);
+
+            int httpMsTime;
+            int.TryParse(httpMs, out httpMsTime);
+
+            bool trackSqlConnections;
+            bool.TryParse(trackSqlConnection, out trackSqlConnections);
+
+            // Dependency checking - if less than configured amount dont track
+            var dependency = item as DependencyTelemetry;
+
+            if (dependency != null)
+            {
+                if (dependency.Type == "Http")
+                {
+                    if (httpMsTime > 0 && dependency.Duration.Milliseconds < httpMsTime)
+                    {
+                        return;
+                    }
+                }
+
+                if (dependency.Type == "SQL")
+                {
+                    // Check to see if we track open commands - the Name contains server | db | command so if 2 or less its an open call
+                    if (!trackSqlConnections)
+                    {
+                        var items = dependency.Name.Split('|');
+                        if (items.Length <= 2)
+                        {
+                            return;
+                        }
+                    }
+                    if (sqlMsTime > 0 && dependency.Duration.Milliseconds < sqlMsTime)
+                    {
+                        return;
+                    }
+                }
+
+                if (dependency.Type == "Azure queue")
+                {
+                    if (queueMsTime > 0 && dependency.Duration.Milliseconds < queueMsTime)
+                    {
+                        return;
+                    }
+                }
+
+
+                if (dependency.Type == "Azure table")
+                {
+                    if (tableMsTime > 0 && dependency.Duration.Milliseconds < tableMsTime)
+                    {
+                        return;
+                    }
+                }
+
+                if (dependency.Type == "Azure blob")
+                {
+                    if (blobMsTime > 0 && dependency.Duration.Milliseconds < blobMsTime)
+                    {
+                        return;
+                    }
+                }
+            }
+            this.Next.Process(item);
+        }
+    }
+
+
+    public class RequestFilter : ITelemetryProcessor
+    {
+        private ITelemetryProcessor Next { get; set; }
+
+        // You can pass values from .config
+        public string MyParamFromConfigFile { get; set; }
+
+        // Link processors to each other in a chain.
+        public RequestFilter(ITelemetryProcessor next)
+        {
+            this.Next = next;
+        }
+        public void Process(ITelemetry item)
+        {
+
+            var httpCode20XMs = Dx1Configuration.GetSetting("HttpCode20xMs");
+            var httpCode30XMs = Dx1Configuration.GetSetting("HttpCode30xMs");
+            
+            int httpCode20XMsTime;
+            int.TryParse(httpCode20XMs, out httpCode20XMsTime);
+
+            int httpCode30XMsTime;
+            int.TryParse(httpCode30XMs, out httpCode30XMsTime);
+              
+
+            // Request checking - if less than configured amount dont track
+            var request = item as RequestTelemetry;
+
+            if (request != null)
+            {
+                 
+
+                if (request.ResponseCode.StartsWith("2", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (httpCode20XMsTime > 0 && request.Duration.Milliseconds < httpCode20XMsTime)
+                    {
+                        return;
+                    }
+
+                }
+
+                if (request.ResponseCode.StartsWith("3", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (httpCode30XMsTime > 0 && request.Duration.Milliseconds < httpCode30XMsTime)
+                    {
+                        return;
+                    }
+                }
+                 
+            }
+            this.Next.Process(item);
+        }
+    }
+
+}

--- a/AppInsightsProvider/AppInsightsLoggingProvider.cs
+++ b/AppInsightsProvider/AppInsightsLoggingProvider.cs
@@ -12,11 +12,38 @@ namespace DotNetNuke.Monitoring.AppInsights
     public class AppInsightsLoggingProvider: DBLoggingProvider
     {
         private static TelemetryClient _appInsightsClient;
-        private static TelemetryClient AppInsightsClient => _appInsightsClient ?? (_appInsightsClient = new TelemetryClient
+        
+        private static TelemetryClient AppInsightsClient
         {
-            InstrumentationKey =
-                TelemetryConfiguration.Active.InstrumentationKey
-        });
+            get
+            {
+                if (_appInsightsClient == null)
+                {
+                    TelemetryConfiguration.Active.TelemetryInitializers.Add(new TelemetryInitializer());
+                    _appInsightsClient = new TelemetryClient
+                                         {
+                                             InstrumentationKey = TelemetryConfiguration.Active.InstrumentationKey
+                                         };
+
+                    // initial processor chain here
+                    var builder = TelemetryConfiguration.Active.TelemetryProcessorChainBuilder;
+                    builder.Use((next) => new DependencyFilter(next));
+                    builder.Use((next) => new RequestFilter(next));
+                    builder.Build();
+
+                    // temporary fix from https://github.com/Microsoft/ApplicationInsights-dotnet/issues/549
+                    foreach (var processor in TelemetryConfiguration.Active.TelemetryProcessors)
+                    {
+                        var telemetryModule = processor as ITelemetryModule;
+                        if (telemetryModule != null)
+                        {
+                            telemetryModule.Initialize(TelemetryConfiguration.Active);
+                        }
+                    }
+                }
+                return _appInsightsClient;
+            }
+        }
 
         public override void AddLog(LogInfo logInfo)
         {   

--- a/AppInsightsProvider/AppInsightsProvider.csproj
+++ b/AppInsightsProvider/AppInsightsProvider.csproj
@@ -93,8 +93,8 @@
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.1, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.1\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
+    <Reference Include="System.Diagnostics.DiagnosticSource, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Diagnostics.DiagnosticSource.4.4.0\lib\net45\System.Diagnostics.DiagnosticSource.dll</HintPath>
     </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net.Http.Formatting">
@@ -114,6 +114,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AITelemetry.cs" />
     <Compile Include="AppInsightsLoggingProvider.cs" />
     <Compile Include="AppInsightsModule.cs" />
     <Compile Include="Components\AppInsightsConfig.cs" />
@@ -138,9 +139,12 @@
     <None Include="app.config">
       <SubType>Designer</SubType>
     </None>
-    <None Include="AppInsightsProvider.dnn" />
+    <None Include="AppInsightsProvider.dnn">
+      <SubType>Designer</SubType>
+    </None>
     <Content Include="ApplicationInsights.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <SubType>Designer</SubType>
     </Content>
     <Content Include="DotNetNuke.log4net.install.config" />
     <Content Include="DotNetNuke.log4net.uninstall.config" />

--- a/AppInsightsProvider/AppInsightsProvider.dnn
+++ b/AppInsightsProvider/AppInsightsProvider.dnn
@@ -57,7 +57,33 @@
             <configFile>web.config</configFile>
             <install>              
               <configuration>
-                <nodes>
+                <nodes appendFromNant="xmlMergeNodes">
+
+                  <!--<appSettings>-->
+                  <!--New appSettings For Dx1 DNN-->
+                  <node path="/configuration/appSettings" action="update" key="key"  collision="overwrite" >
+                    <!--<appSettings for Dependency filter>-->
+                    <add key="SqlMs" value="250"/>
+                    <add key="QueueMs" value="3000"/>
+                    <add key="BlobMs" value="3000"/>
+                    <add key="TableMs" value="3000"/>
+                    <add key="HttpMs" value="3000"/>
+                    <add key="TrackSqlConnection" value="false"/>
+                    <!--<appSettings for Dependency filter>-->
+                    <add key="HttpCode20xMs" value="0"/>
+                    <add key="HttpCode30xMs" value="0"/>
+                  </node>
+
+                  <!-- assemblyBinding-->
+                  <node path="/configuration/runtime/ab:assemblyBinding" action="update"
+                        targetpath="/configuration/runtime/ab:assemblyBinding/ab:dependentAssembly[ab:assemblyIdentity/@name='Microsoft.ApplicationInsights']"
+                        collision="overwrite" nameSpace="urn:schemas-microsoft-com:asm.v1" nameSpacePrefix="ab" owner="DNN">
+                    <dependentAssembly xmlns="urn:schemas-microsoft-com:asm.v1">
+                      <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+                      <bindingRedirect oldVersion="0.0.0.0-2.4.0.0" newVersion="2.4.0.0" />
+                    </dependentAssembly>
+                  </node>
+
                 </nodes>
               </configuration>
             </install>
@@ -68,6 +94,19 @@
                   <node path="/configuration/system.webServer/modules/add[@name='ApplicationInsightsWebTracking']" action="remove" />
                   <node path="/configuration/system.webServer/modules/add[@name='DnnAppInsights']" action="remove" />
                   <node path="/configuration/system.web/httpModules/add[@name='ApplicationInsightsWebTracking']" action="remove" />
+
+                  <!--<appSettings>-->
+                  <!--Remove appSettings For Dx1 DNN-->
+                  <node path="/configuration/appSettings/add[@key='SqlMs']" action="remove"/>
+                  <node path="/configuration/appSettings/add[@key='QueueMs']" action="remove"/>
+                  <node path="/configuration/appSettings/add[@key='BlobMs']" action="remove"/>
+                  <node path="/configuration/appSettings/add[@key='TableMs']" action="remove"/>
+                  <node path="/configuration/appSettings/add[@key='HttpMs']" action="remove"/>
+                  <node path="/configuration/appSettings/add[@key='TrackSqlConnection']" action="remove"/>
+
+                  <node path="/configuration/appSettings/add[@key='HttpCode20xMs']" action="remove"/>
+                  <node path="/configuration/appSettings/add[@key='HttpCode30xMs']" action="remove"/>
+
                 </nodes>
               </configuration>
             </uninstall>

--- a/AppInsightsProvider/Components/MenuController.cs
+++ b/AppInsightsProvider/Components/MenuController.cs
@@ -26,7 +26,7 @@ namespace DotNetNuke.Monitoring.AppInsights.Components
         public IDictionary<string, object> GetSettings(int portalId)
         {
 #if DEBUG
-            var uiUrl = "http://localhost:8080/dist";
+            var uiUrl = "/DesktopModules/Admin/Dnn.PersonaBar/Modules/Dnn.AppInsights";
 #else
             var uiUrl = "/DesktopModules/Admin/Dnn.PersonaBar/Modules/Dnn.AppInsights";            
 #endif

--- a/AppInsightsProvider/ReleaseNotes.txt
+++ b/AppInsightsProvider/ReleaseNotes.txt
@@ -11,3 +11,8 @@
 
 <p style="margin: 0"><b>Version 01.00.00</b></p>
 <p style="margin: 0">This monitoring provider allows to use Visual Studio Application Insights within DNN. Create a new AppInsights account at <a href="https://azure.microsoft.com/en-us/services/application-insights/" target="_new">https://azure.microsoft.com/en-us/services/application-insights/</a></p>
+<br/>
+<p style="margin: 0"><b>NOTES for DX1 Changes</b></p>
+<li style="margin: 0">Add custom properties "podName", "GEO" and "App"</li>
+<li style="margin: 0">Update AI for dependency checking and don't log items with duration less than X</li> 
+<li style="margin: 0">Update AI Request Filter checking and don't log items with duration less than X for HTTP Code 2xx and 3xx.</li> 

--- a/AppInsightsProvider/Web.install.config
+++ b/AppInsightsProvider/Web.install.config
@@ -2,6 +2,8 @@
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <system.webServer>
     <modules>
+      <add xdt:Transform="Remove" xdt:Locator="Condition(@name='TelemetryCorrelationHttpModule')" />
+      <add name="TelemetryCorrelationHttpModule" type="Microsoft.AspNet.TelemetryCorrelation.TelemetryCorrelationHttpModule, Microsoft.AspNet.TelemetryCorrelation" preCondition="managedHandler" xdt:Transform="Insert" />
       <add xdt:Transform="Remove" xdt:Locator="Condition(@name='ApplicationInsightsWebTracking')" />
       <add name="ApplicationInsightsWebTracking" type="Microsoft.ApplicationInsights.Web.ApplicationInsightsHttpModule, Microsoft.AI.Web" preCondition="managedHandler" xdt:Transform="Insert" />
       <add xdt:Transform="Remove" xdt:Locator="Condition(@name='DnnAppInsights')" />

--- a/AppInsightsProvider/Web.uninstall.config
+++ b/AppInsightsProvider/Web.uninstall.config
@@ -2,6 +2,7 @@
 <configuration xmlns:xdt="http://schemas.microsoft.com/XML-Document-Transform">
   <system.webServer>
     <modules>
+      <add xdt:Transform="Remove" xdt:Locator="Condition(@name='TelemetryCorrelationHttpModule')" />
       <add xdt:Transform="Remove" xdt:Locator="Condition(@name='ApplicationInsightsWebTracking')" />
       <add xdt:Transform="Remove" xdt:Locator="Condition(@name='DnnAppInsights')" />
     </modules>

--- a/AppInsightsProvider/js/appinsights.js
+++ b/AppInsightsProvider/js/appinsights.js
@@ -6,3 +6,22 @@ var appInsights=window.appInsights||function(config){
 
 window.appInsights=appInsights;
 appInsights.trackPageView();
+
+// *** DO NOT HAVE SPACE BETWEEN : and "".
+var dx1object = {
+    geo:"",
+    app:"",
+    podName:""
+};
+appInsights.queue.push(function () {
+    appInsights.context.addTelemetryInitializer(function (envelope) {
+        var telemetryItem = envelope.data.baseData;
+
+        // To set custom properties:
+        telemetryItem.properties = telemetryItem.properties || {};
+        telemetryItem.properties["GEO"] = dx1object.geo;
+        telemetryItem.properties["App"] = dx1object.app;
+        telemetryItem.properties["PodName"] = dx1object.podName;
+        telemetryItem.properties["DealershipName"] = window.location.hostname;
+    });
+});

--- a/AppInsightsProvider/packages.config
+++ b/AppInsightsProvider/packages.config
@@ -22,5 +22,5 @@
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net451" />
   <package id="MSBuildTasks" version="1.5.0.235" targetFramework="net451" developmentDependency="true" />
   <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net452" allowedVersions="[7.0.1]" />
-  <package id="System.Diagnostics.DiagnosticSource" version="4.4.1" targetFramework="net452" />
+  <package id="System.Diagnostics.DiagnosticSource" version="4.4.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Adding TelemetryCorrelationHttpModule into web.config when user enable AI.
After install I found that Request Tracking not working because we missing this config. 