### PR TITLE
fix: change uiUrl path from absolute to relative

### DIFF
--- a/AppInsightsProvider/Components/MenuController.cs
+++ b/AppInsightsProvider/Components/MenuController.cs
@@ -28,7 +28,7 @@ namespace DotNetNuke.Monitoring.AppInsights.Components
 #if DEBUG
             var uiUrl = "http://localhost:8080/dist";
 #else
-            var uiUrl = "/DesktopModules/Admin/Dnn.PersonaBar/Modules/Dnn.AppInsights";            
+            var uiUrl = "./Modules/Dnn.AppInsights";            
 #endif
             var apiUrl = "/DesktopModules/Admin/Dnn.PersonaBar/Modules/Dnn.AppInsights";
             var version = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString();


### PR DESCRIPTION
Doing this fixes an error which caused the module not to load when installed on a site's subpage rather than at root